### PR TITLE
Fix UTC timestamps

### DIFF
--- a/lib/primitive_types/date_time_base.dart
+++ b/lib/primitive_types/date_time_base.dart
@@ -57,7 +57,7 @@ abstract class FhirDateTimeBase
         'millisecond': millisecond,
         'microsecond': microsecond,
         'timeZoneOffset': timeZoneOffset,
-        'isUtc': isUtc ? 0 : 1,
+        'isUtc': isUtc ? 1 : 0,
       };
 
   const FhirDateTimeBase({

--- a/lib/primitive_types/date_time_precision.dart
+++ b/lib/primitive_types/date_time_precision.dart
@@ -430,36 +430,44 @@ extension DateTimePrecisionExtension on DateTimePrecision {
   }
 
   DateTime dateTimeFromMap(Map<String, num?> map) {
+    final DateTime utcDateTime = DateTime.utc(
+      map['year'] as int? ?? 0,
+      hasMonth ? map['month'] as int? ?? 0 : 1,
+      hasDay ? map['day'] as int? ?? 0 : 1,
+      hasHours ? map['hour'] as int? ?? 0 : 0,
+      hasMinutes ? map['minute'] as int? ?? 0 : 0,
+      hasSeconds ? map['second'] as int? ?? 0 : 0,
+      hasMilliseconds ? map['millisecond'] as int? ?? 0 : 0,
+      this == DateTimePrecision.dateTime ? map['microsecond'] as int? ?? 0 : 0,
+    );
+
+    // if timestamp is in UTC format, return UTC time
     if (map['isUtc'] != null && map['isUtc'] == 1) {
-      return DateTime.utc(
-        map['year'] as int? ?? 0,
-        hasMonth ? map['month'] as int? ?? 0 : 1,
-        hasDay ? map['day'] as int? ?? 0 : 1,
-        hasHours ? map['hour'] as int? ?? 0 : 0,
-        hasMinutes ? map['minute'] as int? ?? 0 : 0,
-        hasSeconds ? map['second'] as int? ?? 0 : 0,
-        hasMilliseconds ? map['millisecond'] as int? ?? 0 : 0,
-        this == DateTimePrecision.dateTime
-            ? map['microsecond'] as int? ?? 0
-            : 0,
-      );
-    } else {
-      final DateTime dateTime = DateTime.utc(
-        map['year'] as int? ?? 0,
-        hasMonth ? map['month'] as int? ?? 0 : 1,
-        hasDay ? map['day'] as int? ?? 0 : 1,
-        hasHours ? map['hour'] as int? ?? 0 : 0,
-        hasMinutes ? map['minute'] as int? ?? 0 : 0,
-        hasSeconds ? map['second'] as int? ?? 0 : 0,
-        hasMilliseconds ? map['millisecond'] as int? ?? 0 : 0,
-        this == DateTimePrecision.dateTime
-            ? map['microsecond'] as int? ?? 0
-            : 0,
-      );
-      final DateTime localDateTime = dateTime.toLocal();
+      return utcDateTime;
+    }
+
+    if (hasTimezoneOffset) {
+      // timestamp has an explicit offset applied, so it must be converted
+      // to local time and the offset adjusted
+      final DateTime localDateTime = utcDateTime.toLocal();
       final num actualOffset = map['timeZoneOffset'] ?? 0.0;
       return localDateTime
           .subtract(Duration(minutes: (actualOffset * 60.0).round()));
+    } else {
+      // no offset was specified, so the timestamp was in local time from
+      // the beginning - return instance in local time
+      return DateTime(
+        map['year'] as int? ?? 0,
+        hasMonth ? map['month'] as int? ?? 0 : 1,
+        hasDay ? map['day'] as int? ?? 0 : 1,
+        hasHours ? map['hour'] as int? ?? 0 : 0,
+        hasMinutes ? map['minute'] as int? ?? 0 : 0,
+        hasSeconds ? map['second'] as int? ?? 0 : 0,
+        hasMilliseconds ? map['millisecond'] as int? ?? 0 : 0,
+        this == DateTimePrecision.dateTime
+            ? map['microsecond'] as int? ?? 0
+            : 0,
+      );
     }
   }
 

--- a/lib/primitive_types/date_time_precision.dart
+++ b/lib/primitive_types/date_time_precision.dart
@@ -430,31 +430,48 @@ extension DateTimePrecisionExtension on DateTimePrecision {
   }
 
   DateTime dateTimeFromMap(Map<String, num?> map) {
-    final DateTime dateTime = DateTime(
-      map['year'] as int? ?? 0,
-      hasMonth ? map['month'] as int? ?? 0 : 1,
-      hasDay ? map['day'] as int? ?? 0 : 1,
-      hasHours ? map['hour'] as int? ?? 0 : 0,
-      hasMinutes ? map['minute'] as int? ?? 0 : 0,
-      hasSeconds ? map['second'] as int? ?? 0 : 0,
-      hasMilliseconds ? map['millisecond'] as int? ?? 0 : 0,
-      this == DateTimePrecision.dateTime ? map['microsecond'] as int? ?? 0 : 0,
-    );
-    final DateTime localDateTime = dateTime.toLocal();
-    final Duration localOffset = localDateTime.timeZoneOffset;
-    final int actualOffset = localOffset.inHours +
-        (int.tryParse(map['offset']?.toString() ?? '0') ?? 0);
-    final DateTime actualDateTime =
-        localDateTime.add(Duration(hours: actualOffset));
-    return DateTime(
-        actualDateTime.year,
-        actualDateTime.month,
-        actualDateTime.day,
-        actualDateTime.hour - actualOffset,
-        actualDateTime.minute,
-        actualDateTime.second,
-        actualDateTime.millisecond,
-        actualDateTime.microsecond);
+    if (map['isUtc'] != null && map['isUtc'] == 1) {
+      return DateTime.utc(
+        map['year'] as int? ?? 0,
+        hasMonth ? map['month'] as int? ?? 0 : 1,
+        hasDay ? map['day'] as int? ?? 0 : 1,
+        hasHours ? map['hour'] as int? ?? 0 : 0,
+        hasMinutes ? map['minute'] as int? ?? 0 : 0,
+        hasSeconds ? map['second'] as int? ?? 0 : 0,
+        hasMilliseconds ? map['millisecond'] as int? ?? 0 : 0,
+        this == DateTimePrecision.dateTime
+            ? map['microsecond'] as int? ?? 0
+            : 0,
+      );
+    } else {
+      final DateTime dateTime = DateTime(
+        map['year'] as int? ?? 0,
+        hasMonth ? map['month'] as int? ?? 0 : 1,
+        hasDay ? map['day'] as int? ?? 0 : 1,
+        hasHours ? map['hour'] as int? ?? 0 : 0,
+        hasMinutes ? map['minute'] as int? ?? 0 : 0,
+        hasSeconds ? map['second'] as int? ?? 0 : 0,
+        hasMilliseconds ? map['millisecond'] as int? ?? 0 : 0,
+        this == DateTimePrecision.dateTime
+            ? map['microsecond'] as int? ?? 0
+            : 0,
+      );
+      final DateTime localDateTime = dateTime.toLocal();
+      final Duration localOffset = localDateTime.timeZoneOffset;
+      final int actualOffset = localOffset.inHours +
+          (int.tryParse(map['offset']?.toString() ?? '0') ?? 0);
+      final DateTime actualDateTime =
+          localDateTime.add(Duration(hours: actualOffset));
+      return DateTime(
+          actualDateTime.year,
+          actualDateTime.month,
+          actualDateTime.day,
+          actualDateTime.hour - actualOffset,
+          actualDateTime.minute,
+          actualDateTime.second,
+          actualDateTime.millisecond,
+          actualDateTime.microsecond);
+    }
   }
 
   String dateTimeMapToString<T>(Map<String, num?> map) {

--- a/lib/primitive_types/date_time_precision.dart
+++ b/lib/primitive_types/date_time_precision.dart
@@ -444,7 +444,7 @@ extension DateTimePrecisionExtension on DateTimePrecision {
             : 0,
       );
     } else {
-      final DateTime dateTime = DateTime(
+      final DateTime dateTime = DateTime.utc(
         map['year'] as int? ?? 0,
         hasMonth ? map['month'] as int? ?? 0 : 1,
         hasDay ? map['day'] as int? ?? 0 : 1,
@@ -457,20 +457,9 @@ extension DateTimePrecisionExtension on DateTimePrecision {
             : 0,
       );
       final DateTime localDateTime = dateTime.toLocal();
-      final Duration localOffset = localDateTime.timeZoneOffset;
-      final int actualOffset = localOffset.inHours +
-          (int.tryParse(map['offset']?.toString() ?? '0') ?? 0);
-      final DateTime actualDateTime =
-          localDateTime.add(Duration(hours: actualOffset));
-      return DateTime(
-          actualDateTime.year,
-          actualDateTime.month,
-          actualDateTime.day,
-          actualDateTime.hour - actualOffset,
-          actualDateTime.minute,
-          actualDateTime.second,
-          actualDateTime.millisecond,
-          actualDateTime.microsecond);
+      final num actualOffset = map['timeZoneOffset'] ?? 0.0;
+      return localDateTime
+          .subtract(Duration(minutes: (actualOffset * 60.0).round()));
     }
   }
 


### PR DESCRIPTION
This is a tentative fix for #5. The following issues were found:
- `FhirDateTimeBase.toMap()` set `isUtc` to 0 if the timestamp was in UTC and to 1 if it was not in UTC, so the logic seemed to be reversed
- `DateTimePrecision` didn't evaluate the `isUtc` flag and always returned a `DateTime` instance in local time.
- For manual offsets (`+03:00` etc) an incorrect logic was used to translate timestamps to local time, as the calculation was again done from a local timestamp and not a UTC timestamp.

I also admit that I don't fully grasp the logic of the datetime processing code, so I may be wrong with my changes, but my changes correctly calculate timestamps with the following test code:

```dart
import 'package:fhir/r4.dart';

void main(List<String> arguments) {
  final utcFhirDateTime = FhirDateTime("2024-11-25T07:34:15.754Z");
  final utcDateTimeValue = utcFhirDateTime.valueDateTime;

  // UTC timestamps shall be returned as UTC DateTimes, time value unchanged
  print('UTC correct? ${utcFhirDateTime.isUtc == utcDateTimeValue.isUtc}');

  final offsetFhirDateTime = FhirDateTime("2024-11-25T07:34:15.754+02:00");
  final offsetDateTime = offsetFhirDateTime.valueDateTime;

  // timestamps with explicit offset need to be shifted to local time
  // with offset corrected
  print('Offset: FHIR $offsetFhirDateTime, DateTime: $offsetDateTime');

  final localFhirDateTime = FhirDateTime("2024-11-25T07:34:15.754");
  final localDateTime = localFhirDateTime.valueDateTime;

  // local timestamps must be returned in local time, unchanged
  print('Local: FHIR $localFhirDateTime, DateTime: $localDateTime');
}
```