### PR TITLE
Add support for FhirDecimal to be parsed from string decimal

### DIFF
--- a/lib/primitive_types/decimal.dart
+++ b/lib/primitive_types/decimal.dart
@@ -32,6 +32,17 @@ class FhirDecimal extends FhirNumber {
         true,
         int.tryParse(inValue.toString()) != null,
       );
+    } else if (inValue is String) {
+      final double? parsedDouble = double.tryParse(inValue);
+
+      if (parsedDouble != null) {
+        return FhirDecimal._(
+          inValue,
+          parsedDouble,
+          true,
+          int.tryParse(inValue) != null,
+        );
+      }
     }
     throw CannotBeConstructed<FhirDecimal>(
         'Decimal cannot be constructed from $inValue ${inValue.runtimeType}');


### PR DESCRIPTION
Adds support for `FhirDecimal` to be parsed from a `String` type. This should be allowed, since in some systems very large decimal numbers are stored as string type and not a number type.  