### PR TITLE
Update dependencies in pubspec.yaml for compatibility and improvements

### DIFF
--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -5,5 +5,5 @@ environment:
   sdk: '>=2.12.0-0 <3.0.0'
 
 dependencies:
-  fhir: 
-    path: ../../fhir
+  fhir:
+    path: ../

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -17,8 +17,8 @@ environment:
   sdk: ">=3.0.0 <4.0.0"
 
 dependencies:
-  freezed_annotation: ^2.4.1
-  intl: ^0.19.0
+  freezed_annotation: ^3.0.0
+  intl: ^0.20.2
   json_annotation: ^4.8.1
   uuid: ^4.3.3
   xml2json: ^6.2.2
@@ -26,7 +26,7 @@ dependencies:
 
 dev_dependencies:
   build_runner: ^2.4.8
-  freezed: ^2.4.7
+  freezed: ^3.0.6
   # dart run import_sorter:main
   import_sorter: ^4.6.0
   json_serializable: ^6.7.1


### PR DESCRIPTION
This pull request updates dependencies and adjusts the path configuration in `pubspec.yaml` files to align with new versions and project structure changes. The most important changes include upgrading dependency versions and modifying the path to the `fhir` package.

### Dependency Updates:
* [`pubspec.yaml`](diffhunk://#diff-8b7e9df87668ffa6a04b32e1769a33434999e54ae081c52e5d943c541d4c0d25L20-R29): Updated `freezed_annotation` from `^2.4.1` to `^3.0.0` and `intl` from `^0.19.0` to `^0.20.2`. Also updated `freezed` in `dev_dependencies` from `^2.4.7` to `^3.0.6`. These updates ensure compatibility with Dart SDK version `>=3.0.0 <4.0.0`.

### Path Configuration Adjustment:
* [`example/pubspec.yaml`](diffhunk://#diff-565b0869896732da3b937c64bc8fd5f0ca37ea1f629d579c29fc70e0f1e3e48eL9-R9): Changed the `path` for the `fhir` dependency from `../../fhir` to `../`. This simplifies the relative path to match the project's directory structure.